### PR TITLE
fix: convert lists to np.array

### DIFF
--- a/ovos_ww_plugin_openwakeword/__init__.py
+++ b/ovos_ww_plugin_openwakeword/__init__.py
@@ -49,6 +49,8 @@ class OwwHotwordPlugin(HotWordEngine):
         self.audio_buffer.extend(audio_frame)  # build up the buffer until it has enough samples
 
         if len(self.audio_buffer) >= 1280:
+            if isinstance(self.audio_buffer, list):
+                self.audio_buffer = np.asarray(self.audio_buffer)
             # Get prediction from openWakeWord
             prediction = self.model.predict(self.audio_buffer)
 


### PR DESCRIPTION
While working on the latest alpha of Neon.AI on a Mark 2, I discovered that using the hey_jarvis wakeword model threw many of these errors:

```sh
2023-10-29 13:42:55.271 - voice - ovos_dinkum_listener.voice_loop.hotwords:update:311 - ERROR - The input audio data (x) must by a Numpy array, instead received an object of type <class 'list'>.
```

This is using ovos-dinkum-listener 0.0.3a16. It appears that Dinkum is just passing the update request through to the plugin, and when I made the change in this PR, the errors went away.

I tried to make sure this stayed backwards compatible but if I got the logic wrong, please let me know and I'm happy to correct it.