### PR TITLE
fix: support openwakeword 0.6.0

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,30 +4,30 @@ on:
     branches:
       - dev
     paths-ignore:
-      - 'ovos_ww_plugin_openwakeword/version.py'
-      - 'requirements/**'
-      - 'examples/**'
-      - '.github/**'
-      - '.gitignore'
-      - 'LICENSE'
-      - 'CHANGELOG.md'
-      - 'MANIFEST.in'
-      - 'readme.md'
-      - 'scripts/**'
+      - "ovos_ww_plugin_openwakeword/version.py"
+      - "requirements/**"
+      - "examples/**"
+      - ".github/**"
+      - ".gitignore"
+      - "LICENSE"
+      - "CHANGELOG.md"
+      - "MANIFEST.in"
+      - "readme.md"
+      - "scripts/**"
   push:
     branches:
       - master
     paths-ignore:
-      - 'ovos_ww_plugin_openwakeword/version.py'
-      - 'requirements/**'
-      - 'examples/**'
-      - '.github/**'
-      - '.gitignore'
-      - 'LICENSE'
-      - 'CHANGELOG.md'
-      - 'MANIFEST.in'
-      - 'readme.md'
-      - 'scripts/**'
+      - "ovos_ww_plugin_openwakeword/version.py"
+      - "requirements/**"
+      - "examples/**"
+      - ".github/**"
+      - ".gitignore"
+      - "LICENSE"
+      - "CHANGELOG.md"
+      - "MANIFEST.in"
+      - "readme.md"
+      - "scripts/**"
   workflow_dispatch:
 
 jobs:
@@ -35,12 +35,12 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install System Dependencies
@@ -53,7 +53,7 @@ jobs:
           pip install .
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-timeout pytest-cov
+          pip install pytest pytest-timeout pytest-cov ovos_plugin_manager
       - name: Run unittests
         run: |
           pytest --cov=ovos_ww_plugin_openwakeword --cov-report xml test/unittests

--- a/ovos_ww_plugin_openwakeword/__init__.py
+++ b/ovos_ww_plugin_openwakeword/__init__.py
@@ -25,9 +25,9 @@ class OwwHotwordPlugin(HotWordEngine):
     """
 
     def __init__(self, key_phrase="hey jarvis", config=None, lang="en-us"):
+        download_models()
         super().__init__(key_phrase, config, lang)
         # Support for 0.6.0, which removes packaged defaults
-        download_models()
 
         # Load openWakeWord model
         pretrained_models = openwakeword.get_pretrained_model_paths() or []

--- a/ovos_ww_plugin_openwakeword/__init__.py
+++ b/ovos_ww_plugin_openwakeword/__init__.py
@@ -25,9 +25,9 @@ class OwwHotwordPlugin(HotWordEngine):
     """
 
     def __init__(self, key_phrase="hey jarvis", config=None, lang="en-us"):
-        download_models()
         super().__init__(key_phrase, config, lang)
         # Support for 0.6.0, which removes packaged defaults
+        download_models()
 
         # Load openWakeWord model
         pretrained_models = openwakeword.get_pretrained_model_paths() or []

--- a/ovos_ww_plugin_openwakeword/__init__.py
+++ b/ovos_ww_plugin_openwakeword/__init__.py
@@ -26,8 +26,8 @@ class OwwHotwordPlugin(HotWordEngine):
 
     def __init__(self, key_phrase="hey jarvis", config=None, lang="en-us"):
         super().__init__(key_phrase, config, lang)
-        # Support for 0.6.0, which removes packaged defaults, but still requires these models
-        download_models(['melspectrogram', 'silero_vad', 'timer_v0.1', 'weather_v0.1'])
+        # Support for 0.6.0, which removes packaged defaults
+        download_models()
 
         # Load openWakeWord model
         pretrained_models = openwakeword.get_pretrained_model_paths() or []

--- a/ovos_ww_plugin_openwakeword/__init__.py
+++ b/ovos_ww_plugin_openwakeword/__init__.py
@@ -16,6 +16,7 @@ from ovos_plugin_manager.templates.hotwords import HotWordEngine
 from ovos_utils.log import LOG
 import openwakeword
 import numpy as np
+from openwakeword.utils import download_models
 
 class OwwHotwordPlugin(HotWordEngine):
     """OpenWakeWord is an open-source wakeword or phrase engine that can be trained on 100% synthetic data.
@@ -25,11 +26,13 @@ class OwwHotwordPlugin(HotWordEngine):
 
     def __init__(self, key_phrase="hey jarvis", config=None, lang="en-us"):
         super().__init__(key_phrase, config, lang)
+        # Support for 0.6.0, which removes packaged defaults, but still requires these models
+        download_models(['melspectrogram', 'silero_vad', 'timer_v0.1', 'weather_v0.1'])
 
         # Load openWakeWord model
-        pretrained_models = openwakeword.get_pretrained_model_paths()
+        pretrained_models = openwakeword.get_pretrained_model_paths() or []
         self.model = openwakeword.Model(
-            wakeword_model_paths=self.config.get('models', [i for i in pretrained_models if key_phrase in i]),
+            wakeword_models=self.config.get('models', [i for i in pretrained_models if key_phrase in i]),
             custom_verifier_models=self.config.get('custom_verifier_models', {}),
             custom_verifier_threshold=self.config.get('custom_verifier_threshold', 0.1),
             inference_framework=self.config.get('inference_framework', 'tflite')
@@ -70,9 +73,9 @@ class OwwHotwordPlugin(HotWordEngine):
                     self.model.preprocessor.raw_data_buffer.extend([0.0]*n_frames*1280)
                     self.model.preprocessor.feature_buffer[-n_frames:, :] = np.zeros((n_frames, 96)).astype(np.float32)
                     self.model.preprocessor.melspectrogram_buffer[-250:, :] = np.zeros((250, 32)).astype(np.float32)
-                    
+
                     break
-                    
+
 
     def found_wake_word(self, frame_data):
         if self.has_found:

--- a/test/unittests/test_openwakeword_models.py
+++ b/test/unittests/test_openwakeword_models.py
@@ -8,16 +8,13 @@ from ovos_ww_plugin_openwakeword import OwwHotwordPlugin
 class TestOpenWakeWord_plugin(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.model = openwakeword.Model()  # load default models
+        self.model = OwwHotwordPlugin().model  # load default models
 
     def test_model_prediction(self):
         for i in range(10):
             prediction = self.model.predict(np.zeros(1280).astype(np.int16))
         self.assertNotEqual(0.0, prediction[list(self.model.models.keys())[0]])
 
-    def test_default_plugin_loads(self):
-        # Make sure the plugin loads properly
-        OwwHotwordPlugin()
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unittests/test_openwakeword_models.py
+++ b/test/unittests/test_openwakeword_models.py
@@ -3,6 +3,8 @@ import unittest
 import numpy as np
 import openwakeword
 
+from ovos_ww_plugin_openwakeword import OwwHotwordPlugin
+
 class TestOpenWakeWord_plugin(unittest.TestCase):
     @classmethod
     def setUpClass(self):
@@ -12,3 +14,10 @@ class TestOpenWakeWord_plugin(unittest.TestCase):
         for i in range(10):
             prediction = self.model.predict(np.zeros(1280).astype(np.int16))
         self.assertNotEqual(0.0, prediction[list(self.model.models.keys())[0]])
+
+    def test_default_plugin_loads(self):
+        # Make sure the plugin loads properly
+        OwwHotwordPlugin()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
openwakeword version 0.6.0 removes the packaged models. However, we have a few models that need to be available, so we'll make that happen by explicitly downloading them.