### PR TITLE
fix: use canonical opm.* entry-point group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "readme.md"
 requires-python = ">=3.9"
 dependencies = [
     "openwakeword>=0.5.0,<1",
-    "ovos-plugin-manager>=2.1.0,<3.0.0",
+    "ovos-plugin-manager>=2.4.0a1",
     # tflite-runtime (required by openwakeword on Linux) ships C-extensions
     # built against the numpy 1.x ABI and crashes under numpy 2.x with
     # "numpy.core.multiarray failed to import".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ test = [
     "ovos-dinkum-listener",
 ]
 
-[project.entry-points."mycroft.plugin.wake_word"]
+[project.entry-points."opm.wake_word"]
 ovos-ww-plugin-openwakeword = "ovos_ww_plugin_openwakeword:OwwHotwordPlugin"
 
 [project.urls]


### PR DESCRIPTION
Modernize the plugin's entry-point group from the deprecated `mycroft.plugin.wake_word` to the canonical `opm.wake_word` (PluginTypes value in ovos-plugin-manager). The loader aliases the old name, but the canonical group is the current standard.