### PR TITLE
fix: require ovos-plugin-manager>=2.1.0 for opm.* entry points and cap ovos-* deps at next major

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "readme.md"
 requires-python = ">=3.9"
 dependencies = [
     "openwakeword>=0.5.0,<1",
-    "ovos-plugin-manager>=2.4.0a1",
+    "ovos-plugin-manager>=2.1.0,<3.0.0",
     # tflite-runtime (required by openwakeword on Linux) ships C-extensions
     # built against the numpy 1.x ABI and crashes under numpy 2.x with
     # "numpy.core.multiarray failed to import".


### PR DESCRIPTION
The `opm.*` entry-point group(s) declared by this package are only recognized by `ovos-plugin-manager>=2.1.0` (canonical in PluginTypes since 2.1.0; `opm.agents.*` since 2.3.0a1). An older plugin-manager queries the legacy entry-point group and silently never discovers the plugin. Also caps all `ovos-*` dependencies at the next major so the latest published versions resolve.